### PR TITLE
fix: maxLength not working on mobile

### DIFF
--- a/components/form/topic-choice.tsx
+++ b/components/form/topic-choice.tsx
@@ -16,7 +16,7 @@ const TopicChoice = ({ input, handleInputChange }: Props) => {
   const mandateKeyCodes = [8, 35, 36, 37, 38, 39, 40, 46];  // [backspace, end, home, arrow left, arrow up, arrow right, arrow down, delete]
 
   const checkMaxLength = (e: any) => {
-    if(e?.target?.value?.length >= e?.nativeEvent?.srcElement?.maxLength && (!mandateKeyCodes.includes(e?.keyCode))) {
+    if(e?.target?.value?.length >= 200 && (!mandateKeyCodes.includes(e?.keyCode))) {
       e.preventDefault();
     }
   };

--- a/components/form/topic-choice.tsx
+++ b/components/form/topic-choice.tsx
@@ -13,7 +13,14 @@ interface Props {
 
 const TopicChoice = ({ input, handleInputChange }: Props) => {
   const el = useRef(null);
+  const mandateKeyCodes = [8, 35, 36, 37, 38, 39, 40, 46];  // [backspace, end, home, arrow left, arrow up, arrow right, arrow down, delete]
 
+  const checkMaxLength = (e: any) => {
+    if(e?.target?.value?.length >= e?.nativeEvent?.srcElement?.maxLength && (!mandateKeyCodes.includes(e?.keyCode))) {
+      e.preventDefault();
+    }
+  };
+  
   useEffect(() => {
     const typed = new Typed(el.current, {
       strings: [
@@ -50,6 +57,7 @@ const TopicChoice = ({ input, handleInputChange }: Props) => {
           ref={el}
           value={input}
           onChange={handleInputChange}
+          onKeyDown={(e) => checkMaxLength(e)}
           maxLength={200}
         />
         <p


### PR DESCRIPTION
fixes #1 
Added an event handler for `textarea` to limit the max length in mobile devices also.

Since this event handler will also be run when the application is opened in desktop, I have ignored all the navigations keys _(arrow left, right, up, down, home key, end key)_ to prevent the default behavior of input.